### PR TITLE
WIP: Initial commit for lr35902 architechure.

### DIFF
--- a/zorrom/archs.py
+++ b/zorrom/archs.py
@@ -4,6 +4,7 @@ from zorrom import mb8623x
 from zorrom import pic1670
 from zorrom import lc5800
 from zorrom import tutorial
+from zorrom import lr35902
 
 arch2mr = {
     'd8041ah': mcs48.D8041AH,
@@ -14,6 +15,7 @@ arch2mr = {
     #'snes_pif': snes.SnesPIF,
     'lc5800': lc5800.LC5800,
     'tutorial1': tutorial.Tutorial1,
+    'lr35902': lr35902.LR35902,
 }
 
 

--- a/zorrom/lr35902.py
+++ b/zorrom/lr35902.py
@@ -1,0 +1,24 @@
+from zorrom import mrom
+'''
+Reference
+https://www.neviksti.com/DMG/
+
+'''
+
+
+class LR35902(mrom.MaskROM):
+    def desc(self):
+        return 'LR35902'
+
+    def txtwh(self):
+        # 2 groups of 8 bits across, 16 groups of 8 bits down.
+        return (128, 16)
+
+    def invert(self):
+        return False
+
+    '''Given binary (word offset, bit index) return image row/col'''
+    def oi2cr(self, offset, maski):
+        col = ((7 - maski) * 16) + (offset % 16)
+        row = offset // 16
+        return (col, row)


### PR DESCRIPTION
Bug in io2cr(), bytes are transposed, see the following output between gold set (DMG_ROM.bin) and our output (OUT.bin):

yusufm@Yusuf-MPB zorrom % hexdump OUT.bin 
0000000 31 11 47 fe 3e f9 1e 0e 7b 4f 05 03 dc dd 21 f5
0000010 fe 3e 11 34 19 2e 02 13 e2 16 20 73 cc dc 04 06
0000020 ff 80 04 20 ea 0f 0e 24 0c 20 f5 00 6e 99 01 19
0000030 af 32 01 f3 10 18 0c 7c 3e 18 22 83 e6 9f 11 78
0000040 21 e2 21 11 99 f3 f0 1e 87 cb 23 00 dd bb a8 86
0000050 ff 0c 10 d8 21 67 44 83 e2 4f 22 0c dd b9 00 23
0000060 9f 3e 80 00 2f 3e fe fe f0 06 23 00 d9 33 1a 05
0000070 32 f3 1a 06 99 64 90 62 42 04 c9 0d 99 3e 13 20
0000080 cb e2 cd 08 0e 57 20 28 90 c5 ce 00 bb 3c be fb
0000090 7c 32 95 1a 0c e0 fa 06 e0 cb ed 08 bb 42 20 86
00000a0 20 3e 00 13 3d 42 0d 1e 42 11 66 11 67 b9 fe 20
00000b0 fb 77 cd 22 28 3e 20 c1 15 17 66 1f 63 a5 23 fe
00000c0 21 77 96 23 08 91 f7 fe 20 c1 cc 88 6e b9 7d 3e
00000d0 26 3e 00 05 32 e0 1d 64 d2 cb 0d 89 0e a5 fe 01
00000e0 ff fc 13 20 0d 40 20 20 05 11 00 00 ec 42 34 e0
00000f0 0e e0 7b f9 20 04 f2 06 20 17 0b 0e cc 3c 20 50
0000100
yusufm@Yusuf-MPB zorrom % hexdump DMG_ROM.bin 
0000000 31 fe ff af 21 ff 9f 32 cb 7c 20 fb 21 26 ff 0e
0000010 11 3e 80 32 e2 0c 3e f3 e2 32 3e 77 77 3e fc e0
0000020 47 11 04 01 21 10 80 1a cd 95 00 cd 96 00 13 7b
0000030 fe 34 20 f3 11 d8 00 06 08 1a 13 22 23 05 20 f9
0000040 3e 19 ea 10 99 21 2f 99 0e 0c 3d 28 08 32 0d 20
0000050 f9 2e 0f 18 f3 67 3e 64 57 e0 42 3e 91 e0 40 04
0000060 1e 02 0e 0c f0 44 fe 90 20 fa 0d 20 f7 1d 20 f2
0000070 0e 13 24 7c 1e 83 fe 62 28 06 1e c1 fe 64 20 06
0000080 7b e2 0c 3e 87 e2 f0 42 90 e0 42 15 20 d2 05 20
0000090 4f 16 20 18 cb 4f 06 04 c5 cb 11 17 c1 cb 11 17
00000a0 05 20 f5 22 23 22 23 c9 ce ed 66 66 cc 0d 00 0b
00000b0 03 73 00 83 00 0c 00 0d 00 08 11 1f 88 89 00 0e
00000c0 dc cc 6e e6 dd dd d9 99 bb bb 67 63 6e 0e ec cc
00000d0 dd dc 99 9f bb b9 33 3e 3c 42 b9 a5 b9 a5 42 3c
00000e0 21 04 01 11 a8 00 1a 13 be 20 fe 23 7d fe 34 20
00000f0 f5 06 19 78 86 23 05 20 fb 86 20 fe 3e 01 e0 50
0000100